### PR TITLE
2016 bundle version

### DIFF
--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -4,7 +4,8 @@ require_relative "../../lib/cms_validators"
 require_relative "../../lib/encounter_validator"
 
 BUNDLES = {
-  "2016" => HealthDataStandards::CQM::Bundle.find_by(:version.in => ['2.7.0'])
+  "2016" => HealthDataStandards::CQM::Bundle.find_by(version: /^(2.7.0$)|(2016\..*)/) 
+  # 2016 bundle can either be the 2.7.0 bundle, or anything starting with "2016."
 }
 
 

--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -4,8 +4,8 @@ require_relative "../../lib/cms_validators"
 require_relative "../../lib/encounter_validator"
 
 BUNDLES = {
-  "2016" => HealthDataStandards::CQM::Bundle.find_by(version: /^(2.7.0$)|(2016\..*)/) 
-  # 2016 bundle can either be the 2.7.0 bundle, or anything starting with "2016."
+  "2016" => HealthDataStandards::CQM::Bundle.find_by(version: /^2015\./) 
+  # 2016 is the reporting year so we have to use the 2015.x.x bundle ("2015 bundle for the 2016 program year")
 }
 
 


### PR DESCRIPTION
bundle for 2016 reporting year is the 2015.0.0 bundle ("2015 Bundle for the 2016 Reporting Period")

uses a regex to pick any bundle version starting with "2015." to allow for updates