### PR TITLE
Updated Dockerfile and entrypoint so the Dockerfile builds the assets

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+tmp/*/*
+log/*
+public/assets/*
+.git/
+public/uploads/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,6 @@ ADD . /rails/cypress-validation-utility
 
 RUN chmod 755 /rails/cypress-validation-utility/rails-entrypoint.sh
 
+RUN bundle exec rake assets:precompile
+
 EXPOSE 3000

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -72,6 +72,8 @@ Rails.application.configure do
 
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new
+  config.lograge.enabled = true
+  config.logger = Logger.new(STDOUT)
 
 
   #allow requests to run concurrently

--- a/config/initializers/non_digest_assets.rb
+++ b/config/initializers/non_digest_assets.rb
@@ -1,1 +1,1 @@
-NonStupidDigestAssets.whitelist += [/.*.ttf/,/.*.woff/,/.*.woff2/]
+NonStupidDigestAssets.whitelist += [/.*.ttf/, /.*.woff/, /.*.woff2/]

--- a/rails-entrypoint.sh
+++ b/rails-entrypoint.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -e
 
-exec rake assets:precompile &
 exec rails s -b 0.0.0.0
 
 exec "$@"


### PR DESCRIPTION
For some reason, this seems to work (the application will actually ask for and serve valid digested assets) where building them in the `rails-entrypoint.sh` file does not. My working theory: this way the assets are built before the server starts, so the server knows it has compiled assets to serve.