### PR TITLE
Exclude log/ directory during build, and recreate it in Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,5 @@
 tmp/*/*
-log/*
+log/
 public/assets/*
 .git/
 public/uploads/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,8 @@ ADD . /rails/cypress-validation-utility
 
 RUN chmod 755 /rails/cypress-validation-utility/rails-entrypoint.sh
 
+RUN mkdir log/
+
 RUN bundle exec rake assets:precompile
 
 EXPOSE 3000


### PR DESCRIPTION
This both excludes local log files from making it onto the system, and ensures the log/ directory is present for the precompile step.