### PR TITLE
Bundle Measurement Period Overrides

### DIFF
--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -46,3 +46,14 @@ NODE_TYPES ={ 1 => :element ,
               10  => :doc_type,
               11  => :doc_frag,
               12  => :notaion}
+
+BUNDLE_PERIOD_OVERRIDES = {
+  "2015.0.0" => {
+    "measure_period_start" => 1451606400,
+    "effective_date" => 1483228799
+  },
+  "2016.0.0" => {
+    "measure_period_start" => 1483228800,
+    "effective_date" => 1514764799
+  }
+}.freeze

--- a/lib/ext/bundle.rb
+++ b/lib/ext/bundle.rb
@@ -1,0 +1,24 @@
+module HealthDataStandards
+  module CQM
+    class Bundle
+      alias_attribute :orig_effective_date, :effective_date
+      alias_attribute :orig_measure_start, :measure_period_start
+
+      def effective_date
+        if BUNDLE_PERIOD_OVERRIDES[version]
+          return BUNDLE_PERIOD_OVERRIDES[version]['effective_date']
+        else
+          return orig_effective_date
+        end
+      end
+
+      def measure_period_start
+        if BUNDLE_PERIOD_OVERRIDES[version]
+          return BUNDLE_PERIOD_OVERRIDES[version]['measure_period_start']
+        else
+          return orig_measure_start
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Problem: The Cypress bundles don't have the expected start/end values, based on their reporting periods, because people have trouble creating test patients in the future

Solution: Patch `lib/ext/bundle.rb` to get the correct measurement period start and effective date values for our bundles, by pulling them out of a constant in `config/initializers/constants.rb`.