### PR TITLE
Procedure date allowed

### DIFF
--- a/lib/measure_period_validator.rb
+++ b/lib/measure_period_validator.rb
@@ -10,7 +10,8 @@ module CypressValidationUtility
       REPORTING_PERIOD_START = REPORTING_PERIOD_SELECTOR + "/cda:low/@value"
       REPORTING_PERIOD_END = REPORTING_PERIOD_SELECTOR + "/cda:high/@value"
 
-      DISCHARGE_SELECTOR = "/cda:ClinicalDocument/cda:component/cda:structuredBody/cda:component/cda:section[./cda:templateId[@root='2.16.840.1.113883.10.20.17.2.4']]/cda:entry/cda:encounter[./cda:templateId[@root='2.16.840.1.113883.10.20.24.3.23']]/cda:effectiveTime/cda:high/@value"
+      R3_DISCHARGE_SELECTOR = "/cda:ClinicalDocument/cda:component/cda:structuredBody/cda:component/cda:section[./cda:templateId[@root='2.16.840.1.113883.10.20.17.2.4']]/cda:entry/cda:encounter[./cda:templateId[@root='2.16.840.1.113883.10.20.24.3.23']]/cda:effectiveTime/cda:high/@value"
+      R3_1_DISCHARGE_SELECTOR = "/cda:ClinicalDocument/cda:component/cda:structuredBody/cda:component/cda:section[./cda:templateId[@root='2.16.840.1.113883.10.20.17.2.4']]/cda:entry/cda:act[./cda:templateId[@root='2.16.840.1.113883.10.20.24.3.133']]/cda:entryRelationship/cda:encounter[./cda:templateId[@root='2.16.840.1.113883.10.20.24.3.23']]/cda:effectiveTime/cda:high/@value"
       PROCEDURE_SELECTOR = "/cda:ClinicalDocument/cda:component/cda:structuredBody/cda:component/cda:section[./cda:templateId[@root='2.16.840.1.113883.10.20.17.2.4']]/cda:entry/cda:procedure[./cda:templateId[@root='2.16.840.1.113883.10.20.24.3.64']]/cda:effectiveTime/cda:high/@value"
 
       def initialize(program, program_year, doc_type)
@@ -85,7 +86,8 @@ module CypressValidationUtility
 
       def validate_encounter_during_reporting_period
         # pick all the discharge dates and make sure at least one falls within the reporting period
-        discharge_dates = @document.xpath(DISCHARGE_SELECTOR).collect(&:value)
+        discharge_dates = @document.xpath(R3_DISCHARGE_SELECTOR).collect(&:value)
+        discharge_dates += @document.xpath(R3_1_DISCHARGE_SELECTOR).collect(&:value)
         discharge_dates += @document.xpath(PROCEDURE_SELECTOR).collect(&:value)
 
         # it looks like DateTime.parse is smart enough to figure out the date format, ex "20110706122735-0800" -> "Wed, 06 Jul 2011 12:27:35 -0800"

--- a/lib/measure_period_validator.rb
+++ b/lib/measure_period_validator.rb
@@ -11,6 +11,7 @@ module CypressValidationUtility
       REPORTING_PERIOD_END = REPORTING_PERIOD_SELECTOR + "/cda:high/@value"
 
       DISCHARGE_SELECTOR = "/cda:ClinicalDocument/cda:component/cda:structuredBody/cda:component/cda:section[./cda:templateId[@root='2.16.840.1.113883.10.20.17.2.4']]/cda:entry/cda:encounter[./cda:templateId[@root='2.16.840.1.113883.10.20.24.3.23']]/cda:effectiveTime/cda:high/@value"
+      PROCEDURE_SELECTOR = "/cda:ClinicalDocument/cda:component/cda:structuredBody/cda:component/cda:section[./cda:templateId[@root='2.16.840.1.113883.10.20.17.2.4']]/cda:entry/cda:procedure[./cda:templateId[@root='2.16.840.1.113883.10.20.24.3.64']]/cda:effectiveTime/cda:high/@value"
 
       def initialize(program, program_year, doc_type)
         @name = 'Measure Period Validator'
@@ -85,6 +86,7 @@ module CypressValidationUtility
       def validate_encounter_during_reporting_period
         # pick all the discharge dates and make sure at least one falls within the reporting period
         discharge_dates = @document.xpath(DISCHARGE_SELECTOR).collect(&:value)
+        discharge_dates += @document.xpath(PROCEDURE_SELECTOR).collect(&:value)
 
         # it looks like DateTime.parse is smart enough to figure out the date format, ex "20110706122735-0800" -> "Wed, 06 Jul 2011 12:27:35 -0800"
         rp_start_date = DateTime.parse(@rp_start)
@@ -104,7 +106,7 @@ module CypressValidationUtility
         end
 
         unless any_date_within_period
-          msg = 'Documents must contain at least one encounter with a discharge date during the reporting period'
+          msg = 'Documents must contain at least one encounter or procedure with a discharge date during the reporting period'
           @errors << build_error(msg, '/', @options[:file_name])
         end
       end

--- a/test/lib/measure_period_validator_test.rb
+++ b/test/lib/measure_period_validator_test.rb
@@ -53,7 +53,7 @@ class MeasurePeriodValidatorTest < ActiveSupport::TestCase
     errors = validator.validate(@document)
 
     assert_equal 1, errors.count, "Expected 1 error, got #{errors}"
-    msg = 'Documents must contain at least one encounter with a discharge date during the reporting period'
+    msg = 'Documents must contain at least one encounter or procedure with a discharge date during the reporting period'
     assert_equal msg, errors[0].message
   end
 


### PR DESCRIPTION
Create new selectors for discovering procedures and new wrapped format encounters so that the dates can be compared to the reporting period in the "measure period validator".

Test documents (xml as txt):

[18_Edith_Pratt_encounter.xml.txt](https://github.com/projectcypress/cypress-validation-utility/files/687813/18_Edith_Pratt_encounter.xml.txt)
[9_Brenda_Wheeler.xml.txt](https://github.com/projectcypress/cypress-validation-utility/files/687814/9_Brenda_Wheeler.xml.txt)
