### PR TITLE
Correct issue with upload ObjectId being passed around as a string instead of BSON::Object

### DIFF
--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -7,7 +7,7 @@ class Upload
   field :year, type: String
   field :file_count, type: Integer
   field :state, type: Symbol, default: :uploaded
-  field :correlation_id, type: String, default: BSON::ObjectId.new
+  field :correlation_id, type: BSON::ObjectId, default: BSON::ObjectId.new
   field :status_message, type: String
 
   has_one :artifact, :autosave => true, :dependent => :destroy


### PR DESCRIPTION
This was causing issues in the generate_cat3 function which was causing calculation results to not display correctly.

Before fix:
<img width="1194" alt="screen shot 2017-09-28 at 9 19 57 am" src="https://user-images.githubusercontent.com/2308869/30987557-7793d2ca-a465-11e7-8d5f-d87fed27e845.png">

After fix:
![screen shot 2017-09-28 at 3 54 38 pm](https://user-images.githubusercontent.com/2308869/30987573-844cd07a-a465-11e7-9ec0-7893d907d734.png)
