### PR TITLE
enforces using new BSON id when creating new upload

### DIFF
--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -21,7 +21,7 @@ class UploadsController < ApplicationController
     year = params[:year]
 
     @upload = Upload.new(artifact: artf, file_type: file_type,
-                         program: program, year: year, correlation_id: BSON::ObjectId.new)
+                         program: program, year: year)
     @upload.save!(validate: false)
     # TODO: rename errors on the Upload class, so we can remove this validate: false stuff
 

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -21,7 +21,7 @@ class UploadsController < ApplicationController
     year = params[:year]
 
     @upload = Upload.new(artifact: artf, file_type: file_type,
-                         program: program, year: year)
+                         program: program, year: year, correlation_id: BSON::ObjectId.new)
     @upload.save!(validate: false)
     # TODO: rename errors on the Upload class, so we can remove this validate: false stuff
 

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -8,7 +8,7 @@ class Upload
   field :year, type: String
   field :file_count, type: Integer
   field :state, :type => Symbol, :default => :uploaded
-  field :correlation_id, type: BSON::ObjectId, default: BSON::ObjectId.new
+  field :correlation_id, type: BSON::ObjectId, default: -> { BSON::ObjectId.new }
   field :status_message, type: String
 
   has_one :artifact, :autosave => true, :dependent => :destroy


### PR DESCRIPTION
Fixes issue with same file upload multiple times in rapid succession causing upload error

Error observed:
 Error: Unable to evaluate file due to error parsing XML: E11000 duplicate key error collection: cypress_development.patient_cache index: value.measure_id_1_value.sub_id_1_value.effective_date_1_value.patient_id_1 dup key: { : "40280381-52FC-3A32-0153-6127B2F21E0E", : null, : 1483228799.0, : ObjectId('59dcdeeed4b13d03cd0ff386') } (11000) for file '4_FIVE_N_AMI.xml'

Fix seems to work, but would like Rob to check that it hasn't undone any of his recent optimization updates