### PR TITLE
Bumped ruby Docker image version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.2
+FROM ruby:2.3
 
 RUN apt-get update \
     && apt-get install -y nodejs \


### PR DESCRIPTION
CVU used to use Ruby `2.2`, which we bumped to `2.3` in `3.2.2`. This PR bumps the ruby version in the Dockerfile to match the version used by CVU, so things like the safe navigation operator (`&.`) exist.