### PR TITLE
fixed incomplete return statement for updated_negated_good in rationa…

### DIFF
--- a/app/helpers/upload/specifics_helper.rb
+++ b/app/helpers/upload/specifics_helper.rb
@@ -58,19 +58,19 @@ module Upload::SpecificsHelper
   end
 
   ### make updates
-  def updated_negated_good(updated_rationale, rationale, good_occurrence,
+  def updated_negated_good(updated_rationale_param, rationale, good_occurrence,
                            parent_map)
     parent = parent_map[good_occurrence]
     while parent
       # byebug
       # TODO: get rid of array in hash?
       if parent[0][:negation] && rationale[good_occurrence]
-        updated_rationale[good_occurrence] = false
-        return
+        updated_rationale_param[good_occurrence] = false
+        return updated_rationale_param
       end
       parent = parent_map["precondition_#{parent[0][:id]}"]
     end
-    updated_rationale
+    updated_rationale_param
   end
 
   # from each leaf walk up the tree updating the logical statements


### PR DESCRIPTION
…le calculation

When a good rationale is negated and must be because of specific occurrences in the measure hierarchy update was incomplete and returned nil causing "undefined method `[]=' for nil:NilClass" as seen with attached file (CVU params: 2016 bundle, None, QRDA Cat I):
[qdm_15242_20171102084216_9f0fc16d442c4b4c9cd021f7c09b7c8c.xml.zip](https://github.com/projectcypress/cypress-validation-utility/files/1487754/qdm_15242_20171102084216_9f0fc16d442c4b4c9cd021f7c09b7c8c.xml.zip)

After bug fix, measure is now displayed properly.
