### PR TITLE
MIPS program allows for Pick Your Pace reporting period

### DIFF
--- a/app/models/qrda_file.rb
+++ b/app/models/qrda_file.rb
@@ -139,7 +139,7 @@ class QrdaFile
     @validators << CypressValidationUtility::Validate::CCNValidator.instance if program_type == 'eh'
     @validators << HealthDataStandards::Validate::CDA.instance
     @validators << CypressValidationUtility::Validate::ProgramValidator.new(program) unless program == 'none'
-    @validators << CypressValidationUtility::Validate::MeasurePeriodValidator.new(program_type, program_year, doc_type)
+    @validators << CypressValidationUtility::Validate::MeasurePeriodValidator.new(program, program_type, program_year, doc_type)
 
     @validators
   end

--- a/test/lib/measure_period_validator_test.rb
+++ b/test/lib/measure_period_validator_test.rb
@@ -9,7 +9,7 @@ class MeasurePeriodValidatorTest < ActiveSupport::TestCase
   end
 
   test 'Should return error for HQR not aligned to quarter' do
-    validator = CypressValidationUtility::Validate::MeasurePeriodValidator.new('eh', '2016', 'cat1_r3')
+    validator = CypressValidationUtility::Validate::MeasurePeriodValidator.new('HQR_EPM_VOL', 'eh', '2016', 'cat1_r3')
     change_reporting_period(@document, '20160101000000', '20161231000000')
     errors = validator.validate(@document)
 
@@ -19,7 +19,7 @@ class MeasurePeriodValidatorTest < ActiveSupport::TestCase
   end
 
   test 'Should not return error for HQR aligned to quarter' do
-    validator = CypressValidationUtility::Validate::MeasurePeriodValidator.new('eh', '2016', 'cat1_r3')
+    validator = CypressValidationUtility::Validate::MeasurePeriodValidator.new('HQR_EPM_VOL', 'eh', '2016', 'cat1_r3')
     change_reporting_period(@document, '20160401000000', '20160630000000')
     errors = validator.validate(@document)
 
@@ -27,7 +27,7 @@ class MeasurePeriodValidatorTest < ActiveSupport::TestCase
   end
 
   test 'Should return error for PQRS not aligned to year' do
-    validator = CypressValidationUtility::Validate::MeasurePeriodValidator.new('ep', '2016', 'cat1_r3')
+    validator = CypressValidationUtility::Validate::MeasurePeriodValidator.new('CEC', 'ep', '2016', 'cat1_r3')
     change_reporting_period(@document, '20160103000000', '20161230000000')
     errors = validator.validate(@document)
 
@@ -41,15 +41,34 @@ class MeasurePeriodValidatorTest < ActiveSupport::TestCase
   end
 
   test 'Should not return error for PQRS aligned to year' do
-    validator = CypressValidationUtility::Validate::MeasurePeriodValidator.new('ep', '2016', 'cat1_r3')
+    validator = CypressValidationUtility::Validate::MeasurePeriodValidator.new('CEC', 'ep', '2016', 'cat1_r3')
     change_reporting_period(@document, '20160101000000', '20161231000000')
     errors = validator.validate(@document)
 
     assert errors.empty?, "Expected no errors, got #{errors}"
   end
 
+  test 'Should not return error for PQRS not aligned to year with MIPS program' do
+    validator = CypressValidationUtility::Validate::MeasurePeriodValidator.new('MIPS_INDIV', 'ep', '2016', 'cat1_r3')
+    change_reporting_period(@document, '20160103000000', '20161230000000')
+    errors = validator.validate(@document)
+
+    assert errors.empty?, "Expected no errors, got #{errors}"
+  end
+
+  test 'Should return error for PQRS not aligned to year with MIPS program but not at least a day of data' do
+    validator = CypressValidationUtility::Validate::MeasurePeriodValidator.new('MIPS_INDIV', 'ep', '2016', 'cat1_r3')
+    change_reporting_period(@document, '20160103000000', '20160102000000')
+    errors = validator.validate(@document)
+
+    assert_equal 2, errors.count, "Expected 2 error, got #{errors}"
+
+    msg = 'Reported Measurement Period should be at least 1 day'
+    assert_equal msg, errors[0].message
+  end
+
   test 'Should return error for no encounters during rp' do
-    validator = CypressValidationUtility::Validate::MeasurePeriodValidator.new('none', 'none', 'cat1_r3')
+    validator = CypressValidationUtility::Validate::MeasurePeriodValidator.new('none', 'none', 'none', 'cat1_r3')
     change_reporting_period(@document, '22990101000000', '22991231000000')
     errors = validator.validate(@document)
 
@@ -59,7 +78,7 @@ class MeasurePeriodValidatorTest < ActiveSupport::TestCase
   end
 
   test 'Should not throw exception on bad document' do
-    validator = CypressValidationUtility::Validate::MeasurePeriodValidator.new('none', 'none', 'cat1_r3')
+    validator = CypressValidationUtility::Validate::MeasurePeriodValidator.new('none', 'none', 'none', 'cat1_r3')
     @document.xpath('/cda:ClinicalDocument/cda:component').each(&:remove)
 
     errors = validator.validate(@document)


### PR DESCRIPTION
When a MIPS program is selected for a QRDA-III document, the reporting period has no restriction on if it should be a quarter or a year--it just needs to be between 1 day of data and the full year.