### PR TITLE
You need to pass in parameters to validate CV populations

### DIFF
--- a/lib/cat3_population_validator.rb
+++ b/lib/cat3_population_validator.rb
@@ -55,15 +55,14 @@ module CypressValidationUtility
           " is greater than Denominator value #{denom} for measure #{measure}", '/', file)
         end
 
-        errors.concat(validate_cv_populations(file))
+        errors.concat(validate_cv_populations(file, pop, ipp, measure))
       end
 
-      def validate_cv_populations(file)
+      def validate_cv_populations(file, pop, ipp, measure)
         errors = []
         # CVT measures, IPP >= MSRPOPL >= OBSERV
         msrpopl = pop['MSRPOPL'] || 0
         observ = pop['OBSERV'] || 0
-
         if msrpopl > ipp
           errors << build_error("Measure Population value #{msrpopl} is greater than Initial Population value #{ipp} for  "\
           "measure #{measure}", '/', file)
@@ -77,7 +76,8 @@ module CypressValidationUtility
 
       def measure_entry_selector
         '/cda:ClinicalDocument/cda:component/cda:structuredBody/cda:component' \
-          "/cda:section[./cda:templateId[@root='2.16.840.1.113883.10.20.27.2.1']]/cda:entry"
+          "/cda:section[./cda:templateId[@root='2.16.840.1.113883.10.20.27.2.1']]" \
+          "/cda:entry[./cda:organizer/cda:templateId[@root='2.16.840.1.113883.10.20.24.3.98']]"
       end
 
       def measure_id_selector


### PR DESCRIPTION
Pull requests into the Cypress Validation Utility require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code