### PR TITLE
Port zipslip fix to CVU

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ before_script:
 script:
   - bundle exec brakeman -qAzw1
   - bundle exec bundle-audit update
-  - bundle exec bundle-audit check
+  - bundle exec bundle-audit check --ignore CVE-2018-1000544
   - bundle exec overcommit --sign
   - bundle exec overcommit --run
   - travis_retry bundle exec rake test

--- a/lib/ext/central_directory.rb
+++ b/lib/ext/central_directory.rb
@@ -1,0 +1,13 @@
+module Zip
+  class CentralDirectory
+    def entries
+      @entry_set.entries.reject do |entry|
+        entry.symlink? ||
+          Pathname.new(entry.name).absolute? ||
+          # NOTE: This will reject a '..' anywhere in the filename.
+          # The 'more robust' solution is a regex like /\.{2}(?:\/|\z)/
+          entry.name.include?('..')
+      end
+    end
+  end
+end


### PR DESCRIPTION
See https://github.com/projectcypress/cypress/pull/1035 for a description of this issue, the fix, and the tests we did (on Cypress) to validate it

Pull requests into the Cypress Validation Utility require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code