### PR TITLE
Add a procfile for Chef installation

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bundle exec rails s -p $PORT


### PR DESCRIPTION
The Chef installation method for Cypress & the CVU fails, because the CVU is running on the wrong port. This PR adds a `Procfile`, which nudges the port number up 100, which ends up being the right port.

Pull requests into the Cypress Validation Utility require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed

**Reviewer 1:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code