### PR TITLE
Fixed 2019 EH Cat1 Schematron so it will actually run

### DIFF
--- a/resources/schematron/cat1/2019/EH CMS 2019 QRDA Category I.sch
+++ b/resources/schematron/cat1/2019/EH CMS 2019 QRDA Category I.sch
@@ -275,7 +275,7 @@ Wed Mar 21 15:56:18 MDT 2018
     </sch:rule>
     <!-- Added constraint to insure component has only one structured body -->
     <sch:rule id="QDM_based_QRDA_V5-component-errors" context="cda:ClinicalDocument[cda:templateId[@root='2.16.840.1.113883.10.20.24.1.2'][@extension='2017-08-01']]/cda:component">
-      <sch:assert id="a-3343-17081-error" test="count(count(cda:structuredBody))=1">This component SHALL contain exactly one [1..1] structuredBody (CONF:3343-17081).</sch:assert>
+      <sch:assert id="a-3343-17081-error" test="count(cda:structuredBody)=1">This component SHALL contain exactly one [1..1] structuredBody (CONF:3343-17081).</sch:assert>
     </sch:rule>
     <sch:rule id="QDM_based_QRDA_V5-component-structuredBody-errors" context="cda:ClinicalDocument[cda:templateId[@root='2.16.840.1.113883.10.20.24.1.2'][@extension='2017-08-01']]/cda:component/cda:structuredBody">
       <sch:assert id="a-3343-17082-error" test="count(cda:component[count(cda:section[cda:templateId[@root='2.16.840.1.113883.10.20.24.2.3']])=1])=1">This structuredBody SHALL contain exactly one [1..1] component (CONF:3343-17082). This component SHALL contain exactly one [1..1] Measure Section QDM (identifier: urn:oid:2.16.840.1.113883.10.20.24.2.3) (CONF:3343-17083).</sch:assert>
@@ -291,7 +291,7 @@ Wed Mar 21 15:56:18 MDT 2018
       <sch:assert id="a-3343-16586-error" test="count(cda:assignedEntity)=1">Such performers SHALL contain exactly one [1..1] assignedEntity (CONF:3343-16586).</sch:assert>
     </sch:rule>
     <sch:rule id="QDM_based_QRDA_V5-documentationOf-serviceEvent-performer-assignedEntity-errors" context="cda:ClinicalDocument[cda:templateId[@root='2.16.840.1.113883.10.20.24.1.2'][@extension='2017-08-01']]/cda:documentationOf/cda:serviceEvent/cda:performer/cda:assignedEntity">
-      <sch:assert id="a-3343-16591-error" test="count(cda:representedOrganization)=1">This assignedEntity SHALL contain exactly one [1..1] representedOrganization (CONF:3343-16591).</sch:assert>
+      <sch:assert id="a-3343-16591-error-dup" test="count(cda:representedOrganization)=1">This assignedEntity SHALL contain exactly one [1..1] representedOrganization (CONF:3343-16591).</sch:assert>
     </sch:rule>
   </sch:pattern>
   <sch:pattern id="Principal-Diagnosis-pattern-errors">


### PR DESCRIPTION
There were a pair of issues with the 2019 EH Cat I Schematron:

* A pair of schematron rules shared the same ID (`a-3343-16591-error`)
  * Resolved by adding `-dup` to one of the IDs
* A schematron `test` was asking for a `count(count(<xpath expression>))`. This doesn't make any sense semantically, and seems to crash Nokogiri.
   * Resolved by removing the outermost `count()`

This fix is temporary, until we can get CMS to update the Schematron officially.

Pull requests into the Cypress Validation Utility require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/CYPRESS-374
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name: Robert Clark
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code