### PR TITLE
Ubuntu 18 added to pckgr files

### DIFF
--- a/.pkgr.yml
+++ b/.pkgr.yml
@@ -2,4 +2,4 @@ dependencies:
   - mongodb-org-server (= 3.4.5)
 targets:
   ubuntu-16.04:
-  
+  ubuntu-18.04:


### PR DESCRIPTION
Pull requests into the Cypress Validation Utility require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code